### PR TITLE
Define metric

### DIFF
--- a/polytiming.js
+++ b/polytiming.js
@@ -195,7 +195,8 @@
             recorded.push(entryMetrics);
             console.log(entry, entryMetrics)
           });
-          console.log(`${recorded.length} records for ${measure}: ${recorded}`);
+          console.log(`${recorded.length} records for ${measure}:`);
+          console.table(recorded);
           try {
             localStorage.setItem(measure, JSON.stringify(recorded));
           } catch (e) {}

--- a/polytiming.js
+++ b/polytiming.js
@@ -21,11 +21,13 @@
   const measureMetrics = setOfQueryParams('measureMetric');
 
   let shouldTrackElement = (elementName) => true;
+
   if (trackedElements.size > 0) {
     shouldTrackElement = (elementName) => {
       return trackedElements.has(elementName);
     }
   }
+
   let AuthenticPolymer;
   let AuthenticBase;
   let AuthenticTemplatizer;
@@ -41,6 +43,7 @@
 
     set: function(Polymer) {
       AuthenticPolymer = Polymer;
+
       Object.defineProperty(Polymer, 'Base', {
         get: function() {
           return AuthenticBase;
@@ -66,6 +69,7 @@
 
   function measuredMethod(name, work) {
     measuredMethods.add(name);
+
     return function() {
       let element = this.is || this.tagName;
       let elementName = `${element}-${name}`;
@@ -83,6 +87,7 @@
       result = work.apply(this, arguments);
       window.performance.mark(endMark);
       window.performance.measure(elementName, startMark, endMark);
+
       return result;
     };
   }
@@ -99,6 +104,7 @@
     let sum = measures.reduce(function(sum, measure) {
       return sum + measure.duration;
     }, 0);
+
     let average = sum ? sum / count : 0;
 
     return { count, average, sum };
@@ -113,6 +119,7 @@
       if (method === _method) {
         measuredElements.forEach(function(element) {
           let stats = statsForElementMethod(element, method)
+
           sum += stats.sum;
           count += stats.count;
         });
@@ -183,24 +190,32 @@
       window.setTimeout(function() {
         recordedMeasures.forEach(measure => {
           var entries = window.performance.getEntriesByName(measure);
+
           if (!entries.length) {
             console.warn(`No User Timing entries found for ${measure}!`);
+
             return;
           }
+
           try {
             var recorded = JSON.parse(localStorage.getItem(measure));
           } catch (e) {}
+
           recorded = recorded || [];
+
           entries.forEach(entry => {
             let entryMetrics = {}
+
             measureMetrics.forEach(metric => {
               entryMetrics[metric] = entry[metric];
             });
+
             recorded.push(entryMetrics);
-            console.log(entry, entryMetrics)
           });
+
           console.log(`${recorded.length} records for ${measure}:`);
           console.table(recorded);
+
           try {
             localStorage.setItem(measure, JSON.stringify(recorded));
           } catch (e) {}

--- a/polytiming.js
+++ b/polytiming.js
@@ -30,6 +30,10 @@
   let AuthenticBase;
   let AuthenticTemplatizer;
 
+  if (!measureMetrics.size) {
+    measureMetrics.add('duration');
+  }
+
   Object.defineProperty(window, 'Polymer', {
     get: function() {
       return AuthenticPolymer;

--- a/polytiming.js
+++ b/polytiming.js
@@ -7,7 +7,7 @@
           return part.split('=');
         }).reduce(function(l, r) {
           if (r[0] === paramName) {
-            return l.concat(r[1].split(','));
+            return l.concat(r[1].split(/(?:,|%2C)/));
           }
           return l;
         }, []));
@@ -17,7 +17,8 @@
   const measuredMethods = new Set();
   const configuredMethods = setOfQueryParams('instrumentPolymer');
   const trackedElements = setOfQueryParams('trackElement');
-  const recordedMeasures = setOfQueryParams('recordMeasure')
+  const recordedMeasures = setOfQueryParams('recordMeasure');
+  const measureMetrics = setOfQueryParams('measureMetric');
 
   let shouldTrackElement = (elementName) => true;
   if (trackedElements.size > 0) {
@@ -187,7 +188,12 @@
           } catch (e) {}
           recorded = recorded || [];
           entries.forEach(entry => {
-            recorded.push(entry.duration);
+            let entryMetrics = {}
+            measureMetrics.forEach(metric => {
+              entryMetrics[metric] = entry[metric];
+            });
+            recorded.push(entryMetrics);
+            console.log(entry, entryMetrics)
           });
           console.log(`${recorded.length} records for ${measure}: ${recorded}`);
           try {

--- a/polytiming.js
+++ b/polytiming.js
@@ -15,8 +15,10 @@
 
   const measuredElements = new Set();
   const measuredMethods = new Set();
-  const configuredMethods = setOfQueryParams('instrumentPolymer')
-  const trackedElements = setOfQueryParams('trackElement')
+  const configuredMethods = setOfQueryParams('instrumentPolymer');
+  const trackedElements = setOfQueryParams('trackElement');
+  const recordedMeasures = setOfQueryParams('recordMeasure')
+
   let shouldTrackElement = (elementName) => true;
   if (trackedElements.size > 0) {
     shouldTrackElement = (elementName) => {
@@ -166,7 +168,34 @@
       totals[method] = statsForMethod(method);
     });
 
+
     console.table(totals);
     console.table(elementData);
+  }
+
+  if (recordedMeasures.size) {
+    window.addEventListener('load', function() {
+      window.setTimeout(function() {
+        recordedMeasures.forEach(measure => {
+          var entries = window.performance.getEntriesByName(measure);
+          if (!entries.length) {
+            console.warn(`No User Timing entries found for ${measure}!`);
+            return;
+          }
+          try {
+            var recorded = JSON.parse(localStorage.getItem(measure));
+          } catch (e) {}
+          recorded = recorded || [];
+          entries.forEach(entry => {
+            recorded.push(entry.duration);
+          });
+          console.log(`${recorded.length} records for ${measure}: ${recorded}`);
+          try {
+            localStorage.setItem(measure, JSON.stringify(recorded));
+          } catch (e) {}
+        });
+        console.log('Finished recording measures.');
+      }, 1000);
+    });
   }
 })();


### PR DESCRIPTION
duration for some recorded measures is 0. I need to check startTime instead.

Example:

```
https://yolo.swag.sexy/the/path/to/swag?recordMeasure=asdf&measureMetric=startTime,duration
```

(that's actually a TLD)
or if you just want the duration as was default before:

```
https://yolo.swag.sexy/the/path/to/swag?recordMeasure=asdf
```
